### PR TITLE
fix: use `dynamic` parameter instead

### DIFF
--- a/game/story/definitions/character.def.rpy
+++ b/game/story/definitions/character.def.rpy
@@ -1,6 +1,6 @@
 # Character definitions
 # refer to https://www.renpy.org/doc/html/dialogue.html#the-character-store
-define character.p = Character("[prtname]", color="#AAAAAA")  # protagonist
+define character.p = Character("prtname", dynamic=True, color="#AAAAAA")  # protagonist
 define character.n = Character("누리", color="#FFAEC9")
 define character.h = Character("하늘", color="#99D9EA")
 


### PR DESCRIPTION
It [seems](https://www.renpy.org/doc/html/dialogue.html#example-characters) that using the `dynamic` parameter is the appropriate way rather than using the string interpolation syntax, when it comes to have a variable name.

Resolves #15.